### PR TITLE
修复NeuronGroup缺失神经元数量导致Connection.build失败的缺陷，并支持一维卷积

### DIFF
--- a/spaic/Backend/Torch_Backend.py
+++ b/spaic/Backend/Torch_Backend.py
@@ -196,18 +196,37 @@ class Torch_Backend(Backend):
             xshape[0] = xshape[0]*xshape[1]
             extend_size = xshape[1]
             xshape.pop(1)
-            out = fn.conv2d(x.reshape(xshape), kernel, stride=int(stride), padding=int(padding), dilation=int(dilation), groups=int(groups))
+            out = \
+                fn.conv2d(
+                    x.reshape(xshape),
+                    kernel,
+                    stride=tuple(stride.type(torch.int).tolist()),
+                    padding=tuple(padding.type(torch.int).tolist()),
+                    dilation=tuple(dilation.type(torch.int).tolist()),
+                    groups=int(groups))
             outshape = list(out.shape)
             outshape[0] = outshape[0]//extend_size
             outshape.insert(1, extend_size)
             return out.view(outshape)
         else:
-            return fn.conv2d(x, kernel, stride=int(stride), padding=int(padding), dilation=int(dilation), groups=int(groups))
+            return \
+                fn.conv2d(
+                    x,
+                    kernel,
+                    stride=tuple(stride.type(torch.int).tolist()),
+                    padding=tuple(padding.type(torch.int).tolist()),
+                    dilation=tuple(dilation.type(torch.int).tolist()),
+                    groups=int(groups))
 
     def conv_max_pool2d(self, x, kernel, max_kernel, stride, padding, dilation, groups):
-
-        return fn.conv2d(fn.max_pool2d(x, int(max_kernel[0])), kernel, stride=int(stride), padding=int(padding),
-                         dilation=int(dilation), groups=int(groups))
+        return \
+            fn.conv2d(
+                fn.max_pool2d(x, int(max_kernel[0])),
+                kernel,
+                stride=tuple(stride.type(torch.int).tolist()),
+                padding=tuple(padding.type(torch.int).tolist()),
+                dilation=tuple(dilation.type(torch.int).tolist()),
+                groups=int(groups))
 
     def reshape_mat_mult(self, A, X):
 

--- a/spaic/Network/Connection.py
+++ b/spaic/Network/Connection.py
@@ -835,9 +835,9 @@ class conv_connect(Connection):
 
         self.weight = kwargs.get('weight', None)
         self.mask = kwargs.get('mask', None)
-        self.stride = kwargs.get('stride', 1)
-        self.padding = kwargs.get('padding', 0)
-        self.dilation = kwargs.get('dilation', 1)
+        self.stride = kwargs.get('stride', (1, 1))
+        self.padding = kwargs.get('padding', (0, 0))
+        self.dilation = kwargs.get('dilation', (1, 1))
         self.groups = kwargs.get('groups', 1)
 
 
@@ -868,10 +868,18 @@ class conv_connect(Connection):
             Hin = int(Hin / self.maxpool_kernel_size[0])
             Win = int(Win / self.maxpool_kernel_size[1])
 
-        Ho = round((Hin + 2 * self.padding - self.kernel_size[
-            0]) / self.stride + 1)  # Ho = (Hin + 2 * padding[0] - kernel_size[0]) / stride[0] + 1
-        Wo = round((Win + 2 * self.padding - self.kernel_size[
-            1]) / self.stride + 1)  # Wo = (Win + 2 * padding[0] - kernel_size[1]) / stride[0] + 1
+        # Ho = (Hin + 2 * padding[0] - kernel_size[0]) / stride[0] + 1
+        Ho = \
+            round(
+                (Hin + 2 * self.padding[0] - self.kernel_size[0]) / \
+                self.stride[0] + \
+                1)
+        # Wo = (Win + 2 * padding[1] - kernel_size[1]) / stride[1] + 1
+        Wo = \
+            round(
+                (Win + 2 * self.padding[1] - self.kernel_size[1]) / \
+                self.stride[1] + \
+                1)
 
         post_num = int(Ho * Wo * self.out_channels)
 

--- a/spaic/Neuron/Neuron.py
+++ b/spaic/Neuron/Neuron.py
@@ -35,9 +35,8 @@ class NeuronGroup(Assembly):
                  **kwargs
                  ):
         super(NeuronGroup, self).__init__(name=name)
-        self.num = neuron_number
         # self.name = name
-        self.shape = neuron_shape
+        self._set_num_shape(num = neuron_number, shape = neuron_shape)
         self.outlayer = kwargs.get("outlayer", False)
         # self.neuron_model = neuron_model
         if neuron_type == ('excitatory', 'inhibitory', 'pyramidal', '...'):
@@ -60,8 +59,6 @@ class NeuronGroup(Assembly):
         self.model_name = neuron_model  # self.neuron_model -> self.model_name
         self._var_names = list()
         self._operations = OrderedDict()
-
-
 
     def set_parameter(self):
         pass
@@ -90,16 +87,6 @@ class NeuronGroup(Assembly):
         # else:
         #     self.model = self.model_class()
         self.model = self.model_class(**self.parameters)
-        if self.shape is not None:
-            num = np.prod(self.shape)
-            if self.num is None:
-                self.num = num
-            else:
-                assert self.num == num, "the neuron number is not accord with neuron shape"
-        elif self.num is not None:
-            self.shape = [self.num]
-        else:
-            ValueError("neither neuron number nor neuron shape is defined")
 
         dt = backend.dt
         for (key, tau_var) in self.model._tau_constant_variables.items():
@@ -174,6 +161,19 @@ class NeuronGroup(Assembly):
             backend.register_standalone(self.add_neuron_label('V'), self.model.return_V, [])
             backend.register_standalone(self.add_neuron_label('S'), self.model.return_S, [])
 
+    def _set_num_shape(self, num, shape):
+        self.num = num
+        self.shape = shape
+        if self.shape is not None:
+            num = np.prod(self.shape)
+            if self.num is None:
+                self.num = num
+            else:
+                assert self.num == num, "The number of neurons is not consistent with shape."
+        elif self.num is not None:
+            self.shape = [self.num]
+        else:
+            ValueError("The number of neurons or the shape must be defined.")
 
 class NeuronModel(ABC):
     '''


### PR DESCRIPTION
1) 由NeuronGroup.__init__方法（而非NeuronGroup.build方法）更新形状和神经元数量，从而解决Connection.build由于NeuronGroup.num缺失而失败的问题。

2) 将conv_connect的stride、padding和dilation参数改为二元组，允许两个维度的值不同，并相应修改Torch_Backend的实现。