### PR TITLE
修复build_strategy=1不起作用的问题，用于避免sequence结构中的连接延迟问题

### DIFF
--- a/spaic/Network/Network.py
+++ b/spaic/Network/Network.py
@@ -135,8 +135,8 @@ class Network(Assembly):
             # 采取单纯的从头递归地build，一旦出现环路会陷入死循环，可以避开固有延迟的问题,
             # Use directly build strategy to avoid inherent delay. But cannot be used on models with loop, will fall in an endless loop.
             # Unfortunately,
-            self.forward_build(all_groups, all_connections)
             self._backend.forward_build = True
+            self.forward_build(all_groups, all_connections)
         # elif strategy == 2:
         #     # 采取策略性构建，但是目前存在两个问题：
         #     #   1. 网络中存在Assembly块时会出现bug，尚未修复


### PR DESCRIPTION
在Network.build中，strategy=1的情况下，原本在进行forward_build之后才设置self._backend.forward_build = True，使得在connection的构建过程中获取到的forward_build永远是默认值。在修改顺序之后使得forward_build得以起作用